### PR TITLE
Skip basic auth when auth token is set

### DIFF
--- a/service/frontend/middleware/basic_auth.go
+++ b/service/frontend/middleware/basic_auth.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+func BasicAuth(realm string, creds map[string]string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeader := strings.Split(r.Header.Get("Authorization"), " ")
+			if skipBasicAuth(authHeader) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			middleware.BasicAuth("restricted", creds)(next).ServeHTTP(w, r)
+		})
+	}
+}
+
+// skipBasicAuth skips basic auth middleware when the auth token is set
+func skipBasicAuth(authHeader []string) bool {
+	return authToken != nil &&
+		len(authHeader) >= 2 &&
+		authHeader[0] == "Bearer"
+}

--- a/service/frontend/middleware/basic_auth_test.go
+++ b/service/frontend/middleware/basic_auth_test.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicAuthFn(t *testing.T) {
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+	fakeAuthToken := AuthToken{
+		Token: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva",
+	}
+	testCase := []struct {
+		name       string
+		authHeader string
+		authToken  *AuthToken
+		httpStatus int
+	}{
+		{
+			name:       "auth header set, auth token set",
+			authHeader: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva",
+			authToken:  &fakeAuthToken,
+			httpStatus: http.StatusOK,
+		},
+		{
+			name:       "auth header set, auth token unset",
+			authHeader: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva",
+			authToken:  nil,
+			httpStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "auth header unset, auth token set",
+			authHeader: "",
+			authToken:  &fakeAuthToken,
+			httpStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "auth header unset, auth token unset",
+			authHeader: "",
+			authToken:  nil,
+			httpStatus: http.StatusUnauthorized,
+		},
+	}
+	// incorrectCreds triggers HTTP 401 Unauthorized upon basic auth
+	incorrectCreds := map[string]string{
+		"INCORRECT_USERNAME": "INCORRECT_PASSWORD",
+	}
+	for _, tc := range testCase {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := http.NewRequest("GET", "/test", nil)
+			require.NoError(t, err)
+			r.Header.Add("Authorization", tc.authHeader)
+			w := httptest.NewRecorder()
+			authToken = tc.authToken
+			BasicAuth(
+				"restricted",
+				incorrectCreds,
+			)(testHandler).ServeHTTP(w, r)
+			require.Equal(t, tc.httpStatus, w.Result().StatusCode)
+		})
+	}
+}

--- a/service/frontend/middleware/basic_auth_test.go
+++ b/service/frontend/middleware/basic_auth_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBasicAuthFn(t *testing.T) {
+func TestBasicAuth(t *testing.T) {
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))
 	})
+	fakeAuthHeader := "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva"
 	fakeAuthToken := AuthToken{
 		Token: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva",
 	}
@@ -24,13 +25,13 @@ func TestBasicAuthFn(t *testing.T) {
 	}{
 		{
 			name:       "auth header set, auth token set",
-			authHeader: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva",
+			authHeader: fakeAuthHeader,
 			authToken:  &fakeAuthToken,
 			httpStatus: http.StatusOK,
 		},
 		{
 			name:       "auth header set, auth token unset",
-			authHeader: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva",
+			authHeader: fakeAuthHeader,
 			authToken:  nil,
 			httpStatus: http.StatusUnauthorized,
 		},

--- a/service/frontend/middleware/global.go
+++ b/service/frontend/middleware/global.go
@@ -17,9 +17,10 @@ func SetupGlobalMiddleware(handler http.Handler) http.Handler {
 		next = TokenAuth("restricted", authToken.Token)(next)
 	}
 
-	if basicAuth != nil {
-		next = middleware.BasicAuth(
-			"restricted", map[string]string{basicAuth.Username: basicAuth.Password},
+	if authBasic != nil {
+		next = BasicAuth(
+			"restricted",
+			map[string]string{authBasic.Username: authBasic.Password},
 		)(next)
 	}
 	next = prefixChecker(next)
@@ -29,17 +30,17 @@ func SetupGlobalMiddleware(handler http.Handler) http.Handler {
 
 var (
 	defaultHandler http.Handler
-	basicAuth      *BasicAuth
+	authBasic      *AuthBasic
 	authToken      *AuthToken
 )
 
 type Options struct {
 	Handler   http.Handler
-	BasicAuth *BasicAuth
+	AuthBasic *AuthBasic
 	AuthToken *AuthToken
 }
 
-type BasicAuth struct {
+type AuthBasic struct {
 	Username string
 	Password string
 }
@@ -50,7 +51,7 @@ type AuthToken struct {
 
 func Setup(opts *Options) {
 	defaultHandler = opts.Handler
-	basicAuth = opts.BasicAuth
+	authBasic = opts.AuthBasic
 	authToken = opts.AuthToken
 }
 

--- a/service/frontend/server/server.go
+++ b/service/frontend/server/server.go
@@ -91,7 +91,7 @@ func (svr *Server) Serve(ctx context.Context) (err error) {
 		}
 	}
 	if svr.basicAuth != nil {
-		middlewareOptions.BasicAuth = &pkgmiddleware.BasicAuth{
+		middlewareOptions.AuthBasic = &pkgmiddleware.AuthBasic{
 			Username: svr.basicAuth.Username,
 			Password: svr.basicAuth.Password,
 		}


### PR DESCRIPTION
Resolves https://github.com/dagu-dev/dagu/issues/509

Skip basic auth when auth token is set

In addition, I also rename `basicAuth` to `authBasic` for naming consistency with `authToken`
