### PR TITLE
Fix linter error

### DIFF
--- a/service/frontend/middleware/basic_auth_test.go
+++ b/service/frontend/middleware/basic_auth_test.go
@@ -11,7 +11,8 @@ import (
 func TestBasicAuth(t *testing.T) {
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		_, err := w.Write([]byte("OK"))
+		require.NoError(t, err)
 	})
 	fakeAuthHeader := "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva"
 	fakeAuthToken := AuthToken{


### PR DESCRIPTION
Fix error when running `make go-lint`

```
➜  dagu git:(main) ✗ make go-lint
service/frontend/middleware/basic_auth_test.go:14:10: Error return value of `w.Write` is not checked (errcheck)
		w.Write([]byte("OK"))
		       ^
make: *** [Makefile:83: go-lint] Error 1
```

This error affects `make build`, so I think it is quite important to fix this