### PR TITLE
Init dag dir

### DIFF
--- a/internal/persistence/client/store_factory.go
+++ b/internal/persistence/client/store_factory.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"os"
+
 	"github.com/dagu-dev/dagu/internal/config"
 	"github.com/dagu-dev/dagu/internal/persistence"
 	"github.com/dagu-dev/dagu/internal/persistence/jsondb"
@@ -15,9 +17,22 @@ type dataStoreFactoryImpl struct {
 var _ persistence.DataStoreFactory = (*dataStoreFactoryImpl)(nil)
 
 func NewDataStoreFactory(cfg *config.Config) persistence.DataStoreFactory {
-	return &dataStoreFactoryImpl{
+	ds := &dataStoreFactoryImpl{
 		cfg: cfg,
 	}
+	_ = ds.InitDagDir()
+	return ds
+}
+
+func (f dataStoreFactoryImpl) InitDagDir() error {
+	_, err := os.Stat(f.cfg.DAGs)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(f.cfg.DAGs, 0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (f dataStoreFactoryImpl) NewHistoryStore() persistence.HistoryStore {


### PR DESCRIPTION
As this issue: https://github.com/dagu-dev/dagu/issues/530

During the testing process, I found that the scheduler tried to find the directory "$HOME/. dagu/tags" when starting, but it did not create this directory. This can lead to a problem: the scheduler will not be able to start the watcher service when it cannot find this directory, but it will not exit itself. Therefore, when adding a cron task on the page, these cron tasks will not be scheduled. However, when users perform queries or add tasks on the page, the directory of dags will be automatically created. However, since it is not a hot load, the scheduler will not re read this directory, and subsequent watcher services will never start unless the scheduler is manually killed and restarted.
In summary, I believe that adding an initialization process can effectively solve this problem.