### PR TITLE
Fix http query map. Add http console debug.

### DIFF
--- a/internal/executor/http.go
+++ b/internal/executor/http.go
@@ -25,11 +25,12 @@ type HTTPExecutor struct {
 }
 
 type HTTPConfig struct {
-	Timeout     int               `json:"timeout"`
-	Headers     map[string]string `json:"headers"`
-	QueryParams map[string]string `json:"query"`
-	Body        string            `json:"body"`
-	Silent      bool              `json:"silent"`
+	Timeout int               `json:"timeout"`
+	Headers map[string]string `json:"headers"`
+	Query   map[string]string `json:"query"`
+	Body    string            `json:"body"`
+	Silent  bool              `json:"silent"`
+	Debug   bool              `json:"debug"`
 }
 
 var errHttpStatusCode = errors.New("http status code not 2xx")
@@ -90,6 +91,9 @@ func CreateHTTPExecutor(ctx context.Context, step dag.Step) (Executor, error) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	client := resty.New()
+	if reqCfg.Debug {
+		client.SetDebug(true)
+	}
 	if reqCfg.Timeout > 0 {
 		client.SetTimeout(time.Second * time.Duration(reqCfg.Timeout))
 	}
@@ -97,8 +101,8 @@ func CreateHTTPExecutor(ctx context.Context, step dag.Step) (Executor, error) {
 	if len(reqCfg.Headers) > 0 {
 		req = req.SetHeaders(reqCfg.Headers)
 	}
-	if len(reqCfg.QueryParams) > 0 {
-		req = req.SetQueryParams(reqCfg.QueryParams)
+	if len(reqCfg.Query) > 0 {
+		req = req.SetQueryParams(reqCfg.Query)
 	}
 	req = req.SetBody([]byte(reqCfg.Body))
 


### PR DESCRIPTION
http executor does not include query map when configured as documented

bug: key=value is excluded from request

```
steps:
  - name: send POST request
    command: POST https://foo.bar.com
    executor:
      type: http
      config:
        query: 
          key: "value"
```

mapstructure does not read query into QueryParams.  

Rename QueryParams into Query to match yaml

Add debug resty option