### PR TITLE
Fix issue with socket length > 108 due to long task names

### DIFF
--- a/internal/dag/dag.go
+++ b/internal/dag/dag.go
@@ -230,6 +230,13 @@ func (d *DAG) SockAddr() string {
 	h := md5.New()
 	_, _ = h.Write([]byte(s))
 	bs := h.Sum(nil)
+	// Socket name length must be shorter than 108 characters,
+	// so we truncate the name.
+	// 108 - 16 (length of the hash) - 34 (length remaining non-name) - 8 padding = 50
+	lengthLimit := 50
+	if len(name) > lengthLimit {
+		name = name[:lengthLimit-1]
+	}
 	return path.Join("/tmp", fmt.Sprintf("@dagu-%s-%x.sock", name, bs))
 }
 

--- a/internal/dag/dag_test.go
+++ b/internal/dag/dag_test.go
@@ -42,4 +42,10 @@ func TestDAG_SockAddr(t *testing.T) {
 		d := &DAG{Location: "testdata/testDag.yml"}
 		require.Regexp(t, `^/tmp/@dagu-testDag-[0-9a-f]+\.sock$`, d.SockAddr())
 	})
+	t.Run("Unix Socket", func(t *testing.T) {
+		d := &DAG{Location: "testdata/testDagVeryLongNameThatExceedsUnixSocketLengthMaximum-testDagVeryLongNameThatExceedsUnixSocketLengthMaximum.yml"}
+		// 108 is the maximum length of a unix socket address
+		require.Greater(t, 108, len(d.SockAddr()))
+		require.Equal(t, "/tmp/@dagu-testDagVeryLongNameThatExceedsUnixSocketLengthMax-b92b711162d6012f025a76d0cf0b40c2.sock", d.SockAddr())
+	})
 }


### PR DESCRIPTION
Ensures that we truncate task names to no more than 60 chars so they don't exceed the total length limit of 108 that's impose by unix.

Fixes: https://github.com/dagu-dev/dagu/issues/395