### PR TITLE
(ui) Improve UI when using long values in params

### DIFF
--- a/ui/src/components/molecules/NodeStatusTableRow.tsx
+++ b/ui/src/components/molecules/NodeStatusTableRow.tsx
@@ -30,6 +30,11 @@ function NodeStatusTableRow({
     background: 'none',
     outline: 'none',
   };
+  let args = '';
+  if (node.Step.Args) {
+    // Use uninterpolated args to avoid render issues with very long params
+    args = node.Step.CmdWithArgs.replace(node.Step.Command, '').trimStart();
+  }
   return (
     <StyledTableRow>
       <TableCell> {rownum} </TableCell>
@@ -38,7 +43,7 @@ function NodeStatusTableRow({
         <MultilineText>{node.Step.Description}</MultilineText>
       </TableCell>
       <TableCell> {node.Step.Command} </TableCell>
-      <TableCell> {node.Step.Args ? node.Step.Args.join(' ') : ''} </TableCell>
+      <TableCell> {args} </TableCell>
       <TableCell> {node.StartedAt} </TableCell>
       <TableCell> {node.FinishedAt} </TableCell>
       <TableCell>

--- a/ui/src/components/molecules/StartDAGModal.tsx
+++ b/ui/src/components/molecules/StartDAGModal.tsx
@@ -78,7 +78,6 @@ function StartDAGModal({ visible, dag, dismissModal, onSubmit }: Props) {
                 <React.Fragment key={i}>
                   <TextField
                     label={p.Name}
-                    multiline
                     placeholder={p.Value}
                     variant="outlined"
                     style={{
@@ -112,7 +111,6 @@ function StartDAGModal({ visible, dag, dismissModal, onSubmit }: Props) {
                 <React.Fragment key={i}>
                   <TextField
                     label={`Parameter ${i + 1}`}
-                    multiline
                     placeholder={p.Value}
                     variant="outlined"
                     style={{


### PR DESCRIPTION
Fixes: https://github.com/dagu-dev/dagu/issues/594

Screenshots of before and after when using the same dag 
![image](https://github.com/dagu-dev/dagu/assets/1026584/578ed324-5d9d-4b10-a692-3e263b843aff)

<img width="1224" alt="image" src="https://github.com/dagu-dev/dagu/assets/1026584/cc938c50-7e68-44ef-8e2a-8ce8e3d99004">


In the case of long params, the dialogue box is unusable and this is part of a fix to improve their usability.

This change limits each arg to one line and the params remain scrollable to allow for user editing.

For discussion:
1. Does this harm other use cases?
2. Is there a simpler way to accomplish the same ends?

I'm not stuck on this solution but I do see it re-enabling usability of the Start dialogue for cases where the params's value is long.