### PR TITLE
(feat) Add service block to goreleaser brew config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,3 +37,11 @@ brews:
     homepage: 'https://github.com/dagu-dev/dagu'
     description: 'A No-code workflow executor that runs DAGs defined in a simple YAML format'
     license: "GNU General Public License v3.0"
+    custom_block: |
+      service do
+        run [opt_bin/"dagu", "start-all"]
+        keep_alive true
+        error_log_path var/"log/dagu.log"
+        log_path var/"log/dagu.log"
+        working_dir var
+      end


### PR DESCRIPTION
This block allows for dagu to be run as a service under homebrew and it then allows the following commands:

```
brew services status dagu
brew services start dagu
brew services stop dagu
```

When the brew install happens, there is also a prompt to the user in case they want to enable the service or run directly.

The benefit here is that it enables dagu to be run as a background service automatically on startup and controlled via a centralized system.

The resulting local brew formula is:

```ruby
# typed: false
# frozen_string_literal: true

# This file was generated by GoReleaser. DO NOT EDIT.
class Dagu < Formula
  desc "A No-code workflow executor that runs DAGs defined in a simple YAML format"
  homepage "https://github.com/dagu-dev/dagu"
  version "1.13.1-next"
  license "GNU General Public License v3.0"

  on_macos do
    if Hardware::CPU.intel?
      url "https://github.com/zph/dagu/releases/download/v1.13.0/dagu_1.13.1-next_darwin_amd64.tar.gz"
      sha256 "db68710731adfd0aa675804dba264bd13f3e2e639f9bc1cc7d8f33287d49222f"

      def install
        bin.install "dagu"
      end
    end
    if Hardware::CPU.arm?
      url "https://github.com/zph/dagu/releases/download/v1.13.0/dagu_1.13.1-next_darwin_arm64.tar.gz"
      sha256 "3819bab84cf213e6d4e535fe22e70ac62fdaea5c989ff9e9944112ed93f0cf13"

      def install
        bin.install "dagu"
      end
    end
  end

  on_linux do
    if Hardware::CPU.intel?
      url "https://github.com/zph/dagu/releases/download/v1.13.0/dagu_1.13.1-next_linux_amd64.tar.gz"
      sha256 "0984ba37e1e259f432f96a88b882845853d9c1ad43a6a075ab3935f83bb23eb9"

      def install
        bin.install "dagu"
      end
    end
    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
      url "https://github.com/zph/dagu/releases/download/v1.13.0/dagu_1.13.1-next_linux_arm64.tar.gz"
      sha256 "9ace17532f040b4fd55ca7e9fb6781b953c188e91e18d37e9cdd9f9fa067657d"

      def install
        bin.install "dagu"
      end
    end
  end

  service do
    run [opt_bin/"dagu", "start-all"]
    keep_alive true
    error_log_path var/"log/dagu.log"
    log_path var/"log/dagu.log"
    working_dir var
  end
end

```


Related:
- It's possible to have users treat this repo as the homebrew tap rather than needing https://github.com/yohamta/homebrew-tap
- I did that for my fork of https://github.com/zph/tome and I would be happy to put up a separate PR to make those changes (changes to goreleaser and  adding a known folder for homebrew)
- The steps for a user would then be
```
brew tap dagu-dev/dagu https://github.com/dagu-dev/dagu
brew install dagu-dev/dagu/dagu
```

Let me know if you have questions about the homebrew changes :D.