### PR TITLE
(feat) Publish homebrew formula to organization

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,22 +20,38 @@ builds:
     goarm:
       - 7
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
 brews:
+  # DEPRECATED: prefer using dagu-dev/dagu for brew formula
   - repository:
       owner: yohamta
       name: homebrew-tap
     folder: Formula
-    homepage: 'https://github.com/dagu-dev/dagu'
-    description: 'A No-code workflow executor that runs DAGs defined in a simple YAML format'
+    homepage: "https://github.com/dagu-dev/dagu"
+    description: "A No-code workflow executor that runs DAGs defined in a simple YAML format"
+    license: "GNU General Public License v3.0"
+    custom_block: |
+      service do
+        run [opt_bin/"dagu", "start-all"]
+        keep_alive true
+        error_log_path var/"log/dagu.log"
+        log_path var/"log/dagu.log"
+        working_dir var
+      end
+  - repository:
+      owner: dagu-dev
+      name: homebrew-dagu
+    folder: Formula
+    homepage: "https://github.com/dagu-dev/dagu"
+    description: "A No-code workflow executor that runs DAGs defined in a simple YAML format"
     license: "GNU General Public License v3.0"
     custom_block: |
       service do

--- a/README.md
+++ b/README.md
@@ -160,12 +160,12 @@ Download the latest binary from the [Releases page](https://github.com/dagu-dev/
 
 ### Via Homebrew (macOS)
 ```sh
-brew install yohamta/tap/dagu
+brew install dagu-dev/dagu/dagu
 ```
 
 Upgrade to the latest version:
 ```sh
-brew upgrade yohamta/tap/dagu
+brew upgrade dagu-dev/dagu/dagu
 ```
 
 ### Via Docker


### PR DESCRIPTION
Non-urgent but mild usability improvement on homebrew recipe and tap usage.

Related: https://github.com/dagu-dev/dagu/pull/597

With this change the homebrew formula can be installed as:

brew tap dagu-dev/dagu && brew install dagu
OR
brew install dagu-dev/dagu/dagu

Note: this takes advantage of conventions for naming in homebrew and requires setting up a repo of `dagu-dev/homebrew-dagu` which is then automatically referenced when doing `brew tap dagu-dev/dagu`.

Example when I try to do the brew tap command before anything is setup:

```
❯ brew tap dagu-dev/dagu
==> Tapping dagu-dev/dagu
Cloning into '/opt/homebrew/Library/Taps/dagu-dev/homebrew-dagu'...
remote: Repository not found.
fatal: repository 'https://github.com/dagu-dev/homebrew-dagu/' not found
```

I can't test it out, but I believe this will dual push the homebrew recipe to allow for graceful retirement of former location.

Sorry for the auto-format of yaml from single to double quotes, I can revert that part if undesired.

TODO
===

- [ ] Setup repo `dagu-dev/homebrew-dagu` and ensure this GH actions has permissions to it