### PR TITLE
(bug) Remove ansi escape codes from UI Log Display

### DIFF
--- a/ui/src/components/organizations/ExecutionLog.tsx
+++ b/ui/src/components/organizations/ExecutionLog.tsx
@@ -10,10 +10,17 @@ type Props = {
   log?: LogFile;
 };
 
+// Credit: https://github.com/chalk/ansi-regex/commit/02fa893d619d3da85411acc8fd4e2eea0e95a9d9 under MIT license
+const ANSI_CODES_REGEX = [
+  '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+  '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))',
+].join('|');
+
 function ExecutionLog({ log }: Props) {
   if (!log) {
     return <LoadingIndicator />;
   }
+  log.Content = log.Content.replace(new RegExp(ANSI_CODES_REGEX, 'g'), '');
   return (
     <Box>
       <Stack spacing={1} direction="column" sx={{ width: '100%' }}>


### PR DESCRIPTION
Reason: Ansi escape codes are intended to manipulate a terminal and when they're printed they make it more difficult to read the intended log content.

Current output: 
<img width="928" alt="image" src="https://github.com/dagu-dev/dagu/assets/1026584/c4b217a2-a6d9-430f-ad29-9186ede90c61">


Desired output as represented by PR: 
<img width="816" alt="image" src="https://github.com/dagu-dev/dagu/assets/1026584/f39caef4-1fd6-4b35-9ec9-7821f3820fef">

Task definition:
```
steps:
  - name: step1
    command: bash $HOME/src/dagu/tester.sh
```

```bash
# tester.sh
#!/usr/bin/env bash

set -eou pipefail

source $HOME/bin/lib/colors

echo -e "${gre}green text, ${mag}magenta text, ${coloroff}default"
echo -e "${gre}green text, ${mag}magenta text, ${coloroff}default"
echo -e "${gre}green text, ${mag}magenta text, ${coloroff}default"
echo -e "${gre}green text, ${mag}magenta text, ${coloroff}default"
echo -e "${gre}green text, ${mag}magenta text, ${coloroff}default"
echo -e "${gre}green text, ${mag}magenta text, ${coloroff}default"
....
```

$HOME/lib/colors is: https://github.com/zph/dotfiles/blob/master/home/bin/lib/colors with a number of ansii escape codes for injecting color into terminal text.

This will also manifest with terminal based progress bars which use escape codes to refresh the screen's display or move to start of line.

Thanks for reviewing this and let me know if you'd like adjustments or clarification.