### PR TITLE
Propagate Docker container exit code

### DIFF
--- a/internal/dag/executor/docker.go
+++ b/internal/dag/executor/docker.go
@@ -96,7 +96,10 @@ func (e *docker) Run() error {
 		if err != nil {
 			return err
 		}
-	case <-statusCh:
+	case status := <-statusCh:
+		if status.StatusCode != 0 {
+			return fmt.Errorf("exit status %v", status.StatusCode)
+		}
 	}
 
 	out, err := cli.ContainerLogs(

--- a/internal/dag/executor/docker.go
+++ b/internal/dag/executor/docker.go
@@ -88,6 +88,13 @@ func (e *docker) Run() error {
 		return err
 	}
 
+	defer func() {
+		if e.autoRemove {
+			err := cli.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{})
+			util.LogErr("docker executor: remove container", err)
+		}
+	}()
+
 	statusCh, errCh := cli.ContainerWait(
 		ctx, resp.ID, container.WaitConditionNotRunning,
 	)
@@ -111,11 +118,6 @@ func (e *docker) Run() error {
 
 	_, err = stdcopy.StdCopy(e.stdout, e.stdout, out)
 	util.LogErr("docker executor: stdcopy", err)
-
-	if e.autoRemove {
-		err := cli.ContainerRemove(ctx, resp.ID, types.ContainerRemoveOptions{})
-		util.LogErr("docker executor: remove container", err)
-	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes #610 

Status from docker executor is now correctly reported to Dagu on exit:
![image](https://github.com/user-attachments/assets/3e8e8051-0e91-4304-96c9-143c98014a57)
