### PR TITLE
Capture stderr from Docker container

### DIFF
--- a/internal/dag/executor/docker.go
+++ b/internal/dag/executor/docker.go
@@ -99,7 +99,7 @@ func (e *docker) Run() error {
 		ctx, resp.ID, types.ContainerLogsOptions{
 			ShowStdout: true,
 			ShowStderr: true,
-			Follow: true,
+			Follow:     true,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Fixes #611 

Stderr output from Docker container is now correctly captured by Dagu