### PR TITLE
Display execution startAt / finishedAt timezone on Web UI

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -78,10 +78,7 @@ func (e *engineImpl) Rename(oldID, newID string) error {
 		return err
 	}
 	historyStore := e.dataStore.HistoryStore()
-	if err := historyStore.Rename(oldID, newID); err != nil {
-		return err
-	}
-	return nil
+	return historyStore.Rename(oldID, newID)
 }
 
 func (*engineImpl) Stop(dg *dag.DAG) error {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -47,7 +47,6 @@ var (
 
 var (
 	errCreateDAGFile = errors.New("failed to create DAG file")
-	errRenameDAG     = errors.New("failed to rename DAG")
 	errGetStatus     = errors.New("failed to get status")
 	errDAGIsRunning  = errors.New("the DAG is running")
 )
@@ -73,14 +72,14 @@ func (e *engineImpl) Grep(pattern string) (
 	return dagStore.Grep(pattern)
 }
 
-func (e *engineImpl) Rename(oldName, newName string) error {
+func (e *engineImpl) Rename(oldID, newID string) error {
 	dagStore := e.dataStore.DAGStore()
-	if err := dagStore.Rename(oldName, newName); err != nil {
-		return fmt.Errorf("%w: %s", errRenameDAG, err)
+	if err := dagStore.Rename(oldID, newID); err != nil {
+		return err
 	}
 	historyStore := e.dataStore.HistoryStore()
-	if err := historyStore.Rename(oldName, newName); err != nil {
-		return fmt.Errorf("%w: %s", errRenameDAG, err)
+	if err := historyStore.Rename(oldID, newID); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/engine/interface.go
+++ b/internal/engine/interface.go
@@ -9,10 +9,10 @@ import (
 )
 
 type Engine interface {
-	CreateDAG(name string) (string, error)
+	CreateDAG(id string) (string, error)
 	GetDAGSpec(id string) (string, error)
 	Grep(pattern string) ([]*persistence.GrepResult, []string, error)
-	Rename(oldDAGPath, newDAGPath string) error
+	Rename(oldID, newID string) error
 	Stop(dg *dag.DAG) error
 	StartAsync(dg *dag.DAG, params string)
 	Start(dg *dag.DAG, params string) error
@@ -24,7 +24,7 @@ type Engine interface {
 	GetRecentHistory(dg *dag.DAG, n int) []*model.StatusFile
 	UpdateStatus(dg *dag.DAG, status *model.Status) error
 	UpdateDAG(id string, spec string) error
-	DeleteDAG(name, loc string) error
+	DeleteDAG(id, loc string) error
 	GetAllStatus() (statuses []*DAGStatus, errs []string, err error)
 	GetStatus(dagLocation string) (*DAGStatus, error)
 	IsSuspended(id string) bool

--- a/internal/persistence/interface.go
+++ b/internal/persistence/interface.go
@@ -42,7 +42,7 @@ type DAGStore interface {
 	GetDetails(name string) (*dag.DAG, error)
 	Grep(pattern string) (ret []*GrepResult, errs []string, err error)
 	Load(name string) (*dag.DAG, error)
-	Rename(oldName, newName string) error
+	Rename(oldID, newID string) error
 	GetSpec(name string) (string, error)
 	UpdateSpec(name string, spec []byte) error
 	Find(name string) (*dag.DAG, error)

--- a/internal/persistence/jsondb/store.go
+++ b/internal/persistence/jsondb/store.go
@@ -243,11 +243,18 @@ func (*Store) Compact(_, original string) error {
 	return os.Remove(original)
 }
 
-func (s *Store) normalizeInternalName(name string) string {
-	a := strings.TrimSuffix(name, ".yaml")
-	a = strings.TrimSuffix(a, ".yml")
-	a = path.Join(s.dagsDir, a)
-	return fmt.Sprintf("%s.yaml", a)
+var yamlExts = []string{".yaml", ".yml"}
+
+const yamlExt = ".yaml"
+
+func (s *Store) normalizeInternalName(file string) string {
+	for _, ext := range yamlExts {
+		if strings.HasSuffix(file, ext) {
+			file = strings.TrimSuffix(file, ext)
+			break
+		}
+	}
+	return file + yamlExt
 }
 
 func (*Store) exists(file string) bool {

--- a/internal/persistence/jsondb/store.go
+++ b/internal/persistence/jsondb/store.go
@@ -257,10 +257,10 @@ func (*Store) exists(file string) bool {
 	return !os.IsNotExist(err)
 }
 
-func (store *Store) Rename(oldName, newName string) error {
+func (store *Store) Rename(oldID, newID string) error {
 	// This is needed to ensure backward compatibility.
-	on := store.normalizeInternalName(oldName)
-	nn := store.normalizeInternalName(newName)
+	on := store.normalizeInternalName(oldID)
+	nn := store.normalizeInternalName(newID)
 
 	oldDir := store.directory(on, prefix(on))
 	newDir := store.directory(nn, prefix(nn))

--- a/internal/persistence/jsondb/store_test.go
+++ b/internal/persistence/jsondb/store_test.go
@@ -80,7 +80,7 @@ func TestWriteAndFindFiles(t *testing.T) {
 		testWriteStatus(t, db, d, status, data.Timestamp)
 	}
 
-	files := db.latest(db.prefix(d.Location)+"*.dat", 2)
+	files := db.latest(db.prefixWithDirectory(d.Location)+"*.dat", 2)
 	require.Equal(t, 2, len(files))
 }
 
@@ -168,12 +168,12 @@ func TestRemoveOldFiles(t *testing.T) {
 		testWriteStatus(t, db, d, data.Status, data.Timestamp)
 	}
 
-	files := db.latest(db.prefix(d.Location)+"*.dat", 3)
+	files := db.latest(db.prefixWithDirectory(d.Location)+"*.dat", 3)
 	require.Equal(t, 3, len(files))
 
 	_ = db.RemoveOld(d.Location, 0)
 
-	files = db.latest(db.prefix(d.Location)+"*.dat", 3)
+	files = db.latest(db.prefixWithDirectory(d.Location)+"*.dat", 3)
 	require.Equal(t, 0, len(files))
 
 	m := db.latest("invalid-pattern", 3)

--- a/internal/persistence/jsondb/store_test.go
+++ b/internal/persistence/jsondb/store_test.go
@@ -80,7 +80,7 @@ func TestWriteAndFindFiles(t *testing.T) {
 		testWriteStatus(t, db, d, status, data.Timestamp)
 	}
 
-	files := db.latest(db.pattern(d.Location)+"*.dat", 2)
+	files := db.latest(db.prefix(d.Location)+"*.dat", 2)
 	require.Equal(t, 2, len(files))
 }
 
@@ -168,12 +168,12 @@ func TestRemoveOldFiles(t *testing.T) {
 		testWriteStatus(t, db, d, data.Status, data.Timestamp)
 	}
 
-	files := db.latest(db.pattern(d.Location)+"*.dat", 3)
+	files := db.latest(db.prefix(d.Location)+"*.dat", 3)
 	require.Equal(t, 3, len(files))
 
 	_ = db.RemoveOld(d.Location, 0)
 
-	files = db.latest(db.pattern(d.Location)+"*.dat", 3)
+	files = db.latest(db.prefix(d.Location)+"*.dat", 3)
 	require.Equal(t, 0, len(files))
 
 	m := db.latest("invalid-pattern", 3)

--- a/internal/persistence/jsondb/writer_test.go
+++ b/internal/persistence/jsondb/writer_test.go
@@ -51,8 +51,8 @@ func TestWriteStatusToFile(t *testing.T) {
 	oldS := d.Location
 	newS := "text_write_status_new.yaml"
 
-	oldDir := db.directory(oldS, prefix(oldS))
-	newDir := db.directory(newS, prefix(newS))
+	oldDir := db.getDirectory(oldS, prefix(oldS))
+	newDir := db.getDirectory(newS, prefix(newS))
 	require.DirExists(t, oldDir)
 	require.NoDirExists(t, newDir)
 

--- a/internal/persistence/local/dag_store.go
+++ b/internal/persistence/local/dag_store.go
@@ -135,22 +135,21 @@ func (d *dagStoreImpl) fileLocation(name string) (string, error) {
 		// this is for backward compatibility
 		return name, nil
 	}
-	loc := path.Join(d.dir, name)
-	return d.normalizeFilename(loc)
+	return d.normalizeFilename(path.Join(d.dir, name)), nil
 }
 
 var yamlExts = []string{".yaml", ".yml"}
 
 const yamlExt = ".yaml"
 
-func (d *dagStoreImpl) normalizeFilename(file string) (string, error) {
+func (d *dagStoreImpl) normalizeFilename(file string) string {
 	for _, ext := range yamlExts {
 		if strings.HasSuffix(file, ext) {
 			file = strings.TrimSuffix(file, ext)
 			break
 		}
 	}
-	return file + yamlExt, nil
+	return file + yamlExt
 }
 
 func (d *dagStoreImpl) ensureDirExist() error {

--- a/internal/persistence/local/dag_store.go
+++ b/internal/persistence/local/dag_store.go
@@ -135,21 +135,7 @@ func (d *dagStoreImpl) fileLocation(name string) (string, error) {
 		// this is for backward compatibility
 		return name, nil
 	}
-	return d.normalizeFilename(path.Join(d.dir, name)), nil
-}
-
-var yamlExts = []string{".yaml", ".yml"}
-
-const yamlExt = ".yaml"
-
-func (d *dagStoreImpl) normalizeFilename(file string) string {
-	for _, ext := range yamlExts {
-		if strings.HasSuffix(file, ext) {
-			file = strings.TrimSuffix(file, ext)
-			break
-		}
-	}
-	return file + yamlExt
+	return util.AddYamlExtension(path.Join(d.dir, name)), nil
 }
 
 func (d *dagStoreImpl) ensureDirExist() error {

--- a/internal/persistence/local/dag_store.go
+++ b/internal/persistence/local/dag_store.go
@@ -35,23 +35,10 @@ func NewDAGStore(args *NewDAGStoreArgs) persistence.DAGStore {
 	return dagStore
 }
 
-var (
-	errInvalidName           = errors.New("invalid name")
-	errFailedToReadDAGFile   = errors.New("failed to read DAG file")
-	errDOGFileNotExist       = errors.New("the DAG file does not exist")
-	errFailedToUpdateDAGFile = errors.New("failed to update DAG file")
-	errFailedToCreateDAGFile = errors.New("failed to create DAG file")
-	errFailedToCreateDAGsDir = errors.New("failed to create DAGs directory")
-	errFailedToDeleteDAGFile = errors.New("failed to delete DAG file")
-	errDAGFileAlreadyExists  = errors.New("the DAG file already exists")
-	errInvalidNewName        = errors.New("invalid new name")
-	errInvalidOldName        = errors.New("invalid old name")
-)
-
 func (d *dagStoreImpl) GetMetadata(name string) (*dag.DAG, error) {
 	loc, err := d.fileLocation(name)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", errInvalidName, name)
+		return nil, err
 	}
 	return d.metaCache.LoadLatest(loc, func() (*dag.DAG, error) {
 		return dag.LoadMetadata(loc)
@@ -61,7 +48,7 @@ func (d *dagStoreImpl) GetMetadata(name string) (*dag.DAG, error) {
 func (d *dagStoreImpl) GetDetails(name string) (*dag.DAG, error) {
 	loc, err := d.fileLocation(name)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", errInvalidName, name)
+		return nil, err
 	}
 	dat, err := dag.LoadWithoutEval(loc)
 	if err != nil {
@@ -73,17 +60,19 @@ func (d *dagStoreImpl) GetDetails(name string) (*dag.DAG, error) {
 func (d *dagStoreImpl) GetSpec(name string) (string, error) {
 	loc, err := d.fileLocation(name)
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", errInvalidName, name)
+		return "", err
 	}
 	dat, err := os.ReadFile(loc)
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", errFailedToReadDAGFile, err)
+		return "", err
 	}
 	return string(dat), nil
 }
 
 // TODO: use 0600 // nolint: gosec
 const defaultPerm os.FileMode = 0744
+
+var errDOGFileNotExist = errors.New("the DAG file does not exist")
 
 func (d *dagStoreImpl) UpdateSpec(name string, spec []byte) error {
 	// validation
@@ -93,26 +82,28 @@ func (d *dagStoreImpl) UpdateSpec(name string, spec []byte) error {
 	}
 	loc, err := d.fileLocation(name)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errInvalidName, name)
+		return err
 	}
 	if !exists(loc) {
 		return fmt.Errorf("%w: %s", errDOGFileNotExist, loc)
 	}
 	err = os.WriteFile(loc, spec, defaultPerm)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errFailedToUpdateDAGFile, err)
+		return err
 	}
 	d.metaCache.Invalidate(loc)
 	return nil
 }
 
+var errDAGFileAlreadyExists = errors.New("the DAG file already exists")
+
 func (d *dagStoreImpl) Create(name string, spec []byte) (string, error) {
 	if err := d.ensureDirExist(); err != nil {
-		return "", fmt.Errorf("%w: %s", errFailedToCreateDAGsDir, d.dir)
+		return "", err
 	}
 	loc, err := d.fileLocation(name)
 	if err != nil {
-		return "", fmt.Errorf("%w: %s", errFailedToCreateDAGFile, name)
+		return "", err
 	}
 	if exists(loc) {
 		return "", fmt.Errorf("%w: %s", errDAGFileAlreadyExists, loc)
@@ -124,11 +115,11 @@ func (d *dagStoreImpl) Create(name string, spec []byte) (string, error) {
 func (d *dagStoreImpl) Delete(name string) error {
 	loc, err := d.fileLocation(name)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errFailedToCreateDAGFile, name)
+		return err
 	}
 	err = os.Remove(loc)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errFailedToDeleteDAGFile, err)
+		return err
 	}
 	d.metaCache.Invalidate(loc)
 	return nil
@@ -148,10 +139,18 @@ func (d *dagStoreImpl) fileLocation(name string) (string, error) {
 	return d.normalizeFilename(loc)
 }
 
+var yamlExts = []string{".yaml", ".yml"}
+
+const yamlExt = ".yaml"
+
 func (d *dagStoreImpl) normalizeFilename(file string) (string, error) {
-	a := strings.TrimSuffix(file, ".yaml")
-	a = strings.TrimSuffix(a, ".yml")
-	return fmt.Sprintf("%s.yaml", a), nil
+	for _, ext := range yamlExts {
+		if strings.HasSuffix(file, ext) {
+			file = strings.TrimSuffix(file, ext)
+			break
+		}
+	}
+	return file + yamlExt, nil
 }
 
 func (d *dagStoreImpl) ensureDirExist() error {
@@ -255,14 +254,14 @@ func (d *dagStoreImpl) Load(name string) (*dag.DAG, error) {
 	panic("implement me")
 }
 
-func (d *dagStoreImpl) Rename(oldDAGPath, newDAGPath string) error {
-	oldLoc, err := d.fileLocation(oldDAGPath)
+func (d *dagStoreImpl) Rename(oldID, newID string) error {
+	oldLoc, err := d.fileLocation(oldID)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errInvalidOldName, oldDAGPath)
+		return err
 	}
-	newLoc, err := d.fileLocation(newDAGPath)
+	newLoc, err := d.fileLocation(newID)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errInvalidNewName, newDAGPath)
+		return err
 	}
 	return os.Rename(oldLoc, newLoc)
 }

--- a/internal/util/utils.go
+++ b/internal/util/utils.go
@@ -34,8 +34,8 @@ func MustGetwd() string {
 }
 
 const (
-	timeFormat = "2006-01-02 15:04:05"
-	timeEmpty  = "-"
+	legacyTimeFormat = "2006-01-02 15:04:05"
+	timeEmpty        = "-"
 )
 
 // FormatTime returns formatted time.
@@ -44,7 +44,7 @@ func FormatTime(t time.Time) string {
 		return timeEmpty
 	}
 
-	return t.Format(timeFormat)
+	return t.Format(time.RFC3339)
 }
 
 // ParseTime parses time string.
@@ -52,7 +52,10 @@ func ParseTime(val string) (time.Time, error) {
 	if val == timeEmpty {
 		return time.Time{}, nil
 	}
-	return time.ParseInLocation(timeFormat, val, time.Local)
+	if t, err := time.ParseInLocation(time.RFC3339, val, time.Local); err == nil {
+		return t, nil
+	}
+	return time.ParseInLocation(legacyTimeFormat, val, time.Local)
 }
 
 var (

--- a/internal/util/utils.go
+++ b/internal/util/utils.go
@@ -202,3 +202,16 @@ func MatchExtension(file string, exts []string) bool {
 	}
 	return false
 }
+
+// AddYamlExtension adds .yaml extension if not present
+// if it has .yml extension, replace it with .yaml
+func AddYamlExtension(file string) string {
+	ext := filepath.Ext(file)
+	if ext == "" {
+		return file + ".yaml"
+	}
+	if ext == ".yml" {
+		return strings.TrimSuffix(file, ext) + ".yaml"
+	}
+	return file
+}

--- a/internal/util/utils_test.go
+++ b/internal/util/utils_test.go
@@ -34,9 +34,9 @@ func Test_MustGetwd(t *testing.T) {
 
 func Test_FormatTime(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
-		tm := time.Date(2022, 2, 1, 2, 2, 2, 0, time.Now().Location())
+		tm := time.Date(2022, 2, 1, 2, 2, 2, 0, time.UTC)
 		formatted := util.FormatTime(tm)
-		require.Equal(t, "2022-02-01 02:02:02", formatted)
+		require.Equal(t, "2022-02-01T02:02:02Z", formatted)
 
 		parsed, err := util.ParseTime(formatted)
 		require.NoError(t, err)
@@ -56,6 +56,11 @@ func Test_FormatTime(t *testing.T) {
 
 func Test_ParseTime(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
+		parsed, err := util.ParseTime("2022-02-01T02:02:02Z")
+		require.NoError(t, err)
+		require.Equal(t, time.Date(2022, 2, 1, 2, 2, 2, 0, time.UTC), parsed)
+	})
+	t.Run("Valid_Legacy", func(t *testing.T) {
 		parsed, err := util.ParseTime("2022-02-01 02:02:02")
 		require.NoError(t, err)
 		require.Equal(t, time.Date(2022, 2, 1, 2, 2, 2, 0, time.Now().Location()), parsed)

--- a/internal/util/utils_test.go
+++ b/internal/util/utils_test.go
@@ -234,3 +234,43 @@ func TestMatchExtension(t *testing.T) {
 		require.False(t, util.MatchExtension("test.txt", []string{".csv"}))
 	})
 }
+
+func TestAddYamlExtension(t *testing.T) {
+	type args struct {
+		file string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Empty",
+			args: args{
+				file: "",
+			},
+			want: ".yaml",
+		},
+		{
+			name: "WithExtension",
+			args: args{
+				file: "test.yml",
+			},
+			want: "test.yaml",
+		},
+		{
+			name: "WithoutExtension",
+			args: args{
+				file: "test",
+			},
+			want: "test.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := util.AddYamlExtension(tt.args.file); got != tt.want {
+				t.Errorf("AddYamlExtension() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves: #580

Add timezone information to the execution history data. The web UI currently now shows started / finished time with timezone in RFC3339 format.