### PR TITLE
fix: action buttons on the DAG list page don't work for DAGs with custom names

### DIFF
--- a/ui/src/components/molecules/DAGTable.tsx
+++ b/ui/src/components/molecules/DAGTable.tsx
@@ -369,11 +369,14 @@ const defaultColumns = [
       if (data.Type == DAGDataType.Group) {
         return null;
       }
+
+      const name = data.DAGStatus.File.replace(/.yaml$/, '');
+
       return (
         <DAGActions
           dag={data.DAGStatus.DAG}
           status={data.DAGStatus.Status}
-          name={data.DAGStatus.DAG.Name}
+          name={name}
           label={false}
           refresh={props.table.options.meta?.refreshFn}
         />


### PR DESCRIPTION
When a DAG has a custom name defined, the actions buttons on the DAG list page don't work as the frontend uses the custom name instead of the DAG file name to call the "Submit DAG Action" API (`POST /api/v1/dags/:name`).

For example, given a DAG namely `test.yaml` as below:

```yaml
name: Custom Name
steps:
  - name: step1
    command: echo hello
```

When the "Start the DAG" button is clicked from the DAG list page, the following API is called incorrectly:

`POST /api/v1/dags/Custom Name`.

Instead, `POST /api/v1/dags/test` should be called.

<img width="1801" alt="Screenshot 2024-07-22 at 6 20 04 PM" src="https://github.com/user-attachments/assets/c6718685-3937-46bf-b05f-783786526f0b">

To fix it, I simply extract the DAG filename without the `.yaml` extention name from `data.DAGStatus.File`, and then use that as the `name` property on `DAGActions`.
